### PR TITLE
Fix t: prefix doing nothing

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
@@ -271,7 +271,7 @@ public final class ForceFieldManager
             if (offlinePlayer != null)
             {
                 ScoreboardManager manager = Bukkit.getScoreboardManager();
-                Scoreboard board = manager.getNewScoreboard();
+                Scoreboard board = manager.getMainScoreboard();
 
                 Team team = board.getPlayerTeam(offlinePlayer);
 
@@ -693,13 +693,13 @@ public final class ForceFieldManager
                     if (offlinePlayer != null)
                     {
                         ScoreboardManager manager = Bukkit.getScoreboardManager();
-                        Scoreboard board = manager.getNewScoreboard();
+                        Scoreboard board = manager.getMainScoreboard();
 
                         Team team = board.getPlayerTeam(offlinePlayer);
 
                         if (team != null)
                         {
-                            if (tm.equals(team.getName()))
+                            if (tm.equalsIgnoreCase(team.getName()))
                             {
                                 out.add(field);
                             }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/vectors/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/vectors/Field.java
@@ -626,13 +626,13 @@ public class Field extends AbstractVec implements Comparable<Field>
         if (offlinePlayer != null)
         {
             ScoreboardManager manager = Bukkit.getScoreboardManager();
-            Scoreboard board = manager.getNewScoreboard();
+            Scoreboard board = manager.getMainScoreboard();
 
             Team team = board.getPlayerTeam(offlinePlayer);
 
             if (team != null)
             {
-                if (allowed.contains("t:" + team.getName()))
+                if (allowed.contains("t:" + team.getName().toLowerCase()))
                 {
                     return true;
                 }


### PR DESCRIPTION
This pull request fixes the `t:` prefix doing nothing. When executing `/ps allow t:myteam` all members of the team `myteam` should be allowed to the protection. Currently nothing happens.

The code previously checked if the player was in a team on a new, empty scoreboard, which is never the case. The code has been changed to check the main scoreboard instead.

In addition, the plugin stores allowed names as lowercase. This means that the team check has to be case insensitive. This was previously not the case, so this has been changed too.